### PR TITLE
Pull the fix from dev to sort out the order of the countries when creating a "tag" for multi country support.

### DIFF
--- a/R/popRF.R
+++ b/R/popRF.R
@@ -302,7 +302,7 @@ popRF <- function(pop,
   rfg.input.countries <- c()
   
   for ( i in names(cov) ) {
-    rfg.input.countries <- append(rfg.input.countries, i, 1)
+    rfg.input.countries <- append(rfg.input.countries, i)
   } 
   
   


### PR DESCRIPTION
Pull the fix from dev to sort out the order of the countries when creating a "tag" for multi country support.